### PR TITLE
Improve healthchecks to ensure we can generate a PDF

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ app.get(['/healthz', '/livez', '/readyz'], async (req: Request, res: Response) =
 // @TODO: respond with error code if something goes wrong rather than an empty string
 app.post('/', async (req: Request, res: Response) => {
   const options = new Options(
-    req.body.content,
     req.body.filename,
     req.body.saveFile,
     new Format(req.body.format),

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -1,8 +1,6 @@
 import Format from './format'
 
 export default class Options {
-  content: string;
-
   filename: string;
 
   saveFile: boolean;
@@ -12,12 +10,10 @@ export default class Options {
   format: Format;
 
   constructor(
-    content: string,
     filename = `${Date.now()}`,
     saveFile = true,
     format = new Format(),
   ) {
-    this.content = content
     this.saveFile = saveFile
     this.pdfMarkup = ''
     this.filename = filename

--- a/src/utils/generator.ts
+++ b/src/utils/generator.ts
@@ -1,4 +1,4 @@
-import puppeteer, { Page, Browser, PDFOptions } from 'puppeteer'
+import puppeteer, { Page, PDFOptions } from 'puppeteer'
 import StoreFile from './storeFile'
 import Options from '../models/options'
 

--- a/src/utils/generator.ts
+++ b/src/utils/generator.ts
@@ -1,4 +1,4 @@
-import puppeteer, { Page, PDFOptions } from 'puppeteer'
+import puppeteer, { Browser, Page, PDFOptions } from 'puppeteer'
 import StoreFile from './storeFile'
 import Options from '../models/options'
 
@@ -41,6 +41,7 @@ export default class Generator {
 
   private async generatePDF(): Promise<Buffer> {
     let pdfContent: Buffer
+    let browser: Browser
     const isLocal = process.env.NODE_ENV === 'development'
     let puppeteerOptions: Record<string, string | string[]>
 
@@ -61,9 +62,8 @@ export default class Generator {
     // https://developer.chrome.com/articles/new-headless/
     puppeteerOptions.headless = 'new'
 
-    const browser = await puppeteer.launch(puppeteerOptions)
-
     try {
+      browser = await puppeteer.launch(puppeteerOptions)
       const page: Page = await browser.newPage()
       const defaultOptions: PDFOptions = {
         format: 'a4',
@@ -75,10 +75,10 @@ export default class Generator {
       await page.setContent(this.content)
 
       pdfContent = await page.pdf(defaultOptions)
+
+      await browser.close()
     } catch (e) {
       console.log(`Error generating the PDF: ${e}`)
-    } finally {
-      await browser.close()
     }
 
     return new Promise<Buffer>((resolve) => {

--- a/src/utils/generator.ts
+++ b/src/utils/generator.ts
@@ -47,7 +47,7 @@ export default class Generator {
       printBackground: true,
     })
 
-    browser.close()
+    await browser.close()
 
     return !!pdfContent.length
   }


### PR DESCRIPTION
This improves the healthcheck endpoints by ensuring we can both launch puppeteer and generate a PDF with it

Also includes some smaller code cleanups